### PR TITLE
Native Python Structure dumped by pickle

### DIFF
--- a/run.py
+++ b/run.py
@@ -77,6 +77,11 @@ def run(args):
     plots.plot_final_results(env, results, start_time)
 
     with open('./results/{}/results-final.h5'.format(env.output_folder), 'wb') as file:
+        results = dict(results)
+        for k,v in results.items():
+            results[k] = dict(v);
+            for k2,v2 in results[k].items():
+                results[k][k2] = list(v2)
         pickle.dump(results, file)
 
     logger.debug('Finishing simulation after {}'.format(datetime.timedelta(seconds=(time.time() - start_time))))


### PR DESCRIPTION
A Manager structure (list or dict) can't be dumped directly by pickle, it must be casted by a native python structure (dict or list). This is not a pretty solution but it is functional.